### PR TITLE
chore: migrate to .NET SDK `10.0.300`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,8 +23,8 @@
         "ghcr.io/devcontainers-contrib/features/starship:1": {},
         // https://github.com/devcontainers/features/blob/main/src/dotnet/README.md
         "ghcr.io/devcontainers/features/dotnet:2": {
-            "version": "9.0",
-            "additionalVersions": "8.0"
+            "version": "10.0",
+            "additionalVersions": "9.0,8.0"
         }
     },
     "overrideFeatureInstallOrder": [

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build main
+﻿name: Build main
 
 on:
   push:
@@ -17,9 +17,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup necessary dotnet SDKs
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
           dotnet-version: |
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Build and run dev container task
         uses: devcontainers/ci@v0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           global-json-file: global.json
           dotnet-version: |
-            9.x
+            10.x
             8.x
 
       - name: Build via Bash

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           global-json-file: global.json
           dotnet-version: |
-            9.x
+            10.x
             8.x
 
       - name: Install Azure Cosmos DB Emulator

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,4 +1,4 @@
-name: "Copilot Setup Steps"
+﻿name: "Copilot Setup Steps"
 
 # Automatically run the setup steps when they are changed to allow for easy validation, and
 # allow manual testing through the repository's "Actions" tab
@@ -26,10 +26,10 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup necessary dotnet SDKs
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
           dotnet-version: |

--- a/.github/workflows/fsdocs-gh-pages.yml
+++ b/.github/workflows/fsdocs-gh-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs
+﻿name: Deploy Docs
 
 on:
   # Runs on pushes targeting the default branch
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Setup necessary dotnet SDKs
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
           dotnet-version: |
@@ -44,7 +44,7 @@ jobs:
           ./build.sh builddocs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/fsdocs-gh-pages.yml
+++ b/.github/workflows/fsdocs-gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           global-json-file: global.json
           dotnet-version: |
-            9.x
+            10.x
 
       - name: Build Docs
         run: |

--- a/.github/workflows/publish_ci.yml
+++ b/.github/workflows/publish_ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           global-json-file: global.json
           dotnet-version: |
-            9.x
+            10.x
             8.x
 
       - name: Add the GitHub source

--- a/.github/workflows/publish_ci.yml
+++ b/.github/workflows/publish_ci.yml
@@ -1,4 +1,4 @@
-name: Publish to GitHub
+﻿name: Publish to GitHub
 
 on:
   push:
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup necessary dotnet SDKs
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
           dotnet-version: |

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,4 +1,4 @@
-name: Publish to NuGet
+﻿name: Publish to NuGet
 
 on:
   push:
@@ -16,9 +16,9 @@ jobs:
       name: nuget
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup necessary dotnet SDKs
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
           dotnet-version: |

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           global-json-file: global.json
           dotnet-version: |
-            9.x
+            10.x
             8.x
 
       - name: Publish to NuGet

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@ See https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-director
 
   <PropertyGroup>
     <AssemblyBaseName>FSharp.Azure.Cosmos</AssemblyBaseName>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>

--- a/build/build.fs
+++ b/build/build.fs
@@ -362,7 +362,8 @@ let dotnetTest ctx =
     let args = [
         "--no-build"
         if enableCodeCoverage then
-            "--collect:\"Code Coverage\""
+            "--collect"
+            "Code Coverage"
             "--results-directory"
             testResultsDir
         "--logger:trx" // Enable TRX report generation
@@ -708,7 +709,8 @@ let initTargets (ctx : Context.FakeExecutionContext) =
 
     "DotnetRestore" ==>! "WatchTests"
 
-    //"DotnetToolRestore" ?=>! "DotnetRestore"
+    "DotnetRestore" ==>! "DotnetToolRestore"
+    "DotnetToolRestore" ==>! "DotnetBuild"
     "DotnetToolRestore" ==>! "BuildDocs"
     "DotnetToolRestore" ?=>! "CheckFormatCode"
     "DotnetToolRestore" ?=>! "FormatCode"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.300",
+    "version": "10.0.300",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
## Proposed Changes

Migrates the project toolchain from .NET SDK `9.0.300` to `10.0.300`. All GitHub Actions workflows (`build`, `publish_ci`, `publish_release`, `fsdocs-gh-pages`, and `copilot-setup-steps`) are updated to install the `10.x` SDK alongside `8.x`. `global.json` is pinned to `10.0.300`, and `Directory.Build.props` advances the F# language version from `9.0` to `10.0` to allow use of the latest language features.

## Types of changes

What types of changes does your code introduce to FSharp.Azure.Cosmos?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)