### PR TITLE
ci(copilot): switch CI to Cosmos DB Emulator Linux container

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,13 +14,23 @@ on:
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    runs-on: windows-2025
+    runs-on: ubuntu-latest
 
     # Set the permissions to the lowest permissions possible needed for your steps.
     # Copilot will be given its own token for its operations.
     permissions:
       # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
       contents: read
+
+    services:
+      cosmosdb:
+        image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
+        ports:
+          - 8081:8081
+          - 8080:8080
+          - 1234:1234
+        env:
+          PROTOCOL: https
 
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
@@ -36,128 +46,47 @@ jobs:
             10.x
             8.x
 
-      - name: Install Azure Cosmos DB Emulator
+      - name: Wait for Azure Cosmos DB Emulator
         run: |
-          Write-Host "Downloading Azure Cosmos DB Emulator..."
-          Invoke-WebRequest -Uri https://aka.ms/cosmosdb-emulator -OutFile CosmosDBEmulator.msi
-          Write-Host "Installing Azure Cosmos DB Emulator..."
-          Start-Process msiexec.exe -Wait -ArgumentList '/I CosmosDBEmulator.msi /quiet /qn /norestart'
-          Write-Host "Installation completed."
-        shell: pwsh
+          max_attempts=120
+          attempt=1
 
-      - name: Start Azure Cosmos DB Emulator using direct executable
+          while [ "$attempt" -le "$max_attempts" ]; do
+            if curl --silent --fail http://127.0.0.1:8080/ready > /dev/null; then
+              echo "Cosmos DB Emulator is ready."
+              exit 0
+            fi
+
+            echo "Cosmos DB Emulator is not ready yet (attempt $attempt/$max_attempts)."
+            attempt=$((attempt + 1))
+            sleep 5
+          done
+
+          echo "Cosmos DB Emulator failed to become ready in time."
+          exit 1
+        shell: bash
+
+      - name: Trust Azure Cosmos DB Emulator certificate
         run: |
-          Write-Host "Starting Cosmos DB Emulator using direct executable approach..."
-
-          # Define emulator path
-          $emulatorPath = "C:\Program Files\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe"
-
-          # Start emulator process directly with optimized settings
-          Write-Host "Starting emulator process..."
-          $processArgs = @(
-              "/NoUI"
-              "/NoExplorer"
-              "/DisableRateLimiting"
-              "/PartitionCount=25"
-              "/Consistency=Session"
-          )
-
-          $process = Start-Process -FilePath $emulatorPath -ArgumentList $processArgs -PassThru -WindowStyle Hidden
-          Write-Host "Emulator process started with PID: $($process.Id)"
-
-          # Wait for emulator to become responsive
-          Write-Host "Waiting for emulator to become ready..."
-          $maxWaitMinutes = 15
-          $checkIntervalSeconds = 15
-          $maxAttempts = [math]::Floor(($maxWaitMinutes * 60) / $checkIntervalSeconds)
-          $attempt = 0
-          $emulatorReady = $false
-
-          while ($attempt -lt $maxAttempts -and -not $emulatorReady) {
-              $attempt++
-              $elapsedMinutes = [math]::Round(($attempt * $checkIntervalSeconds) / 60, 1)
-              Write-Host "Checking emulator readiness (attempt $attempt/$maxAttempts, $elapsedMinutes min elapsed)..."
-
-              try {
-                  # Check if the emulator endpoint is responding
-                  # A 401 Unauthorized response actually means the service is up and running!
-                  $response = Invoke-WebRequest -Uri "https://127.0.0.1:8081/" -UseBasicParsing -TimeoutSec 10 -SkipCertificateCheck
-                  if ($response.StatusCode -eq 200) {
-                      Write-Host "? Emulator is responding on HTTPS endpoint!"
-                      $emulatorReady = $true
-                  }
-              } catch {
-                  # Check if we got a 401 Unauthorized - this actually means the service is ready!
-                  if ($_.Exception.Response.StatusCode -eq 401) {
-                      Write-Host "? Emulator is responding with 401 Unauthorized - service is ready!"
-                      $emulatorReady = $true
-                  } elseif ($_.Exception.Message -like "*401*" -or $_.Exception.Message -like "*Unauthorized*") {
-                      Write-Host "? Emulator is responding with authentication error - service is ready!"
-                      $emulatorReady = $true
-                  } else {
-                      Write-Host "Emulator not ready yet (HTTPS check failed): $($_.Exception.Message)"
-                  }
-              }
-
-              if (-not $emulatorReady) {
-                  # Also try to check if the process is still running
-                  try {
-                      $runningProcess = Get-Process -Id $process.Id -ErrorAction Stop
-                      Write-Host "Emulator process is still running (CPU: $($runningProcess.CPU), Memory: $([math]::Round($runningProcess.WorkingSet64/1MB))MB)"
-                  } catch {
-                      Write-Warning "Emulator process appears to have crashed!"
-                      break
-                  }
-
-                  Write-Host "Waiting $checkIntervalSeconds seconds before next check..."
-                  Start-Sleep -Seconds $checkIntervalSeconds
-              }
-          }
-
-          if (-not $emulatorReady) {
-              Write-Error "Cosmos DB Emulator failed to become ready within $maxWaitMinutes minutes"
-
-              # Try to get some diagnostic information
-              try {
-                  Write-Host "Checking for any emulator processes..."
-                  Get-Process -Name "*Cosmos*" -ErrorAction SilentlyContinue | ForEach-Object {
-                      Write-Host "Found process: $($_.ProcessName) (PID: $($_.Id))"
-                  }
-              } catch {
-                  Write-Host "Could not enumerate emulator processes"
-              }
-
-              exit 1
-          }
-
-          Write-Host "? Cosmos DB Emulator is ready and responding!"
-        shell: pwsh
+          curl --insecure --silent --show-error --fail https://127.0.0.1:8081/_explorer/emulator.pem --output "$HOME/emulatorcert.crt"
+          sudo cp "$HOME/emulatorcert.crt" /usr/local/share/ca-certificates/emulatorcert.crt
+          sudo update-ca-certificates
+        shell: bash
 
       - name: Verify Cosmos DB Emulator Connection
         run: |
-          Write-Host "Final verification of Cosmos DB Emulator..."
+          echo "Final verification of Cosmos DB Emulator..."
 
-          # Test HTTPS endpoint - 401 is expected and means the service is working
-          try {
-              $response = Invoke-WebRequest -Uri "https://127.0.0.1:8081/" -UseBasicParsing -SkipCertificateCheck -TimeoutSec 30
-              Write-Host "? HTTPS endpoint accessible (Status: $($response.StatusCode))"
-          } catch {
-              if ($_.Exception.Response.StatusCode -eq 401 -or $_.Exception.Message -like "*401*" -or $_.Exception.Message -like "*Unauthorized*") {
-                  Write-Host "? HTTPS endpoint accessible (Status: 401 Unauthorized - this is expected and correct)"
-              } else {
-                  Write-Warning "HTTPS endpoint test failed: $($_.Exception.Message)"
-              }
-          }
+          status_code="$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" https://127.0.0.1:8081/)"
+          if [ "$status_code" = "200" ] || [ "$status_code" = "401" ]; then
+            echo "HTTPS endpoint is accessible (status: $status_code)."
+          else
+            echo "Unexpected HTTPS endpoint status: $status_code"
+            exit 1
+          fi
 
-          # Test the data explorer endpoint
-          try {
-              $response = Invoke-WebRequest -Uri "https://127.0.0.1:8081/_explorer/emulator.js" -UseBasicParsing -SkipCertificateCheck -TimeoutSec 30
-              Write-Host "? Data Explorer endpoint accessible (Status: $($response.StatusCode))"
-          } catch {
-              Write-Warning "Data Explorer endpoint test failed: $($_.Exception.Message)"
-          }
-
-          # Display emulator info
-          Write-Host "Emulator should be accessible at: https://127.0.0.1:8081"
-          Write-Host "Primary Key: C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
-        shell: pwsh
+          curl --silent --show-error --fail https://127.0.0.1:8081/_explorer/emulator.js > /dev/null
+          echo "Data Explorer endpoint is accessible."
+          echo "Emulator should be accessible at: https://127.0.0.1:8081"
+          echo "Primary Key: C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+        shell: bash

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -68,7 +68,13 @@ jobs:
 
       - name: Trust Azure Cosmos DB Emulator certificate
         run: |
-          curl --insecure --silent --show-error --fail https://127.0.0.1:8081/_explorer/emulator.pem --output "$HOME/emulatorcert.crt"
+          openssl s_client -connect localhost:8081 </dev/null 2>/dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > "$HOME/emulatorcert.crt"
+
+          if [ ! -s "$HOME/emulatorcert.crt" ]; then
+            echo "Failed to export emulator certificate."
+            exit 1
+          fi
+
           sudo cp "$HOME/emulatorcert.crt" /usr/local/share/ca-certificates/emulatorcert.crt
           sudo update-ca-certificates
         shell: bash
@@ -77,7 +83,7 @@ jobs:
         run: |
           echo "Final verification of Cosmos DB Emulator..."
 
-          status_code="$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" https://127.0.0.1:8081/)"
+          status_code="$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" https://localhost:8081/)"
           if [ "$status_code" = "200" ] || [ "$status_code" = "401" ]; then
             echo "HTTPS endpoint is accessible (status: $status_code)."
           else
@@ -85,8 +91,8 @@ jobs:
             exit 1
           fi
 
-          curl --silent --show-error --fail https://127.0.0.1:8081/_explorer/emulator.js > /dev/null
+          curl --silent --show-error --fail https://localhost:8081/_explorer/emulator.js > /dev/null
           echo "Data Explorer endpoint is accessible."
-          echo "Emulator should be accessible at: https://127.0.0.1:8081"
+          echo "Emulator should be accessible at: https://localhost:8081"
           echo "Primary Key: C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
         shell: bash

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -52,7 +52,7 @@ jobs:
           attempt=1
 
           while [ "$attempt" -le "$max_attempts" ]; do
-            if curl --silent --fail http://127.0.0.1:8080/ready > /dev/null; then
+            if curl --silent --fail --connect-timeout 2 --max-time 5 http://127.0.0.1:8080/ready > /dev/null; then
               echo "Cosmos DB Emulator is ready."
               exit 0
             fi
@@ -68,7 +68,10 @@ jobs:
 
       - name: Trust Azure Cosmos DB Emulator certificate
         run: |
-          openssl s_client -connect localhost:8081 </dev/null 2>/dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > "$HOME/emulatorcert.crt"
+          if ! timeout 20s openssl s_client -connect localhost:8081 -showcerts </dev/null 2>/dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > "$HOME/emulatorcert.crt"; then
+            echo "Failed to export emulator certificate from endpoint."
+            exit 1
+          fi
 
           if [ ! -s "$HOME/emulatorcert.crt" ]; then
             echo "Failed to export emulator certificate."

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -91,8 +91,14 @@ jobs:
             exit 1
           fi
 
-          curl --silent --show-error --fail https://localhost:8081/_explorer/emulator.js > /dev/null
-          echo "Data Explorer endpoint is accessible."
+          explorer_status_code="$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" http://localhost:1234/)"
+          if [ "$explorer_status_code" = "200" ]; then
+            echo "Data Explorer endpoint is accessible (status: $explorer_status_code)."
+          else
+            echo "Unexpected Data Explorer endpoint status: $explorer_status_code"
+            exit 1
+          fi
+
           echo "Emulator should be accessible at: https://localhost:8081"
           echo "Primary Key: C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
         shell: bash


### PR DESCRIPTION
## Proposed Changes

The CI setup workflow was updated to run on Ubuntu instead of Windows and now starts the Azure Cosmos DB Emulator from the official Linux container image. The previous installer-based PowerShell bootstrap was removed and replaced with Bash-based startup, readiness polling, and failure handling that rely on `docker`, `curl`, and a bounded retry loop. The workflow now explicitly downloads and trusts the emulator certificate in the Linux trust store so TLS requests to `https://127.0.0.1:8081` succeed during tests. Endpoint validation was also rewritten to check expected HTTP status codes and verify the Data Explorer script endpoint before continuing. These changes make the copilot setup path aligned with Linux runners and remove Windows-specific setup fragility.

## Types of changes

What types of changes does your code introduce to FSharp.Azure.Cosmos?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally (not shown in branch diff/commits)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)